### PR TITLE
Feature/icon abstraction

### DIFF
--- a/react-native/component-demo/storybook/stories/channel-value.tsx
+++ b/react-native/component-demo/storybook/stories/channel-value.tsx
@@ -4,10 +4,15 @@ import { View } from 'react-native';
 import { ChannelValue } from '@pxblue/react-native-components';
 import { text, withKnobs, boolean, number, color } from '@storybook/addon-knobs';
 import Leaf from '@pxblue/icons-svg/leaf.svg';
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
+import { wrapIcon } from '@pxblue/react-native-components/dist/icon-wrapper/icon-wrapper';
 
 const notes = {
   notes: 'Any React Element may be passed in as `icon`; if using an svg, its color and size are not controlled by `ChannelValue`'
 };
+
+const WrappedLeaf = wrapIcon({ IconClass: Leaf });
+const WrappedIcon = wrapIcon({ IconClass: Icon, name: 'chart-pie' });
 
 storiesOf('ChannelValue', module)
   .addDecorator(withKnobs)
@@ -22,7 +27,7 @@ storiesOf('ChannelValue', module)
     <View style={{flex: 1, alignItems: 'center', justifyContent: 'center'}}>
       <ChannelValue
         value={text('value', text('value', '123'))}
-        icon={<Leaf width={40} height={40} fill={'#44cc44'}/>}
+        IconClass={WrappedLeaf}
       />
     </View>
   ), notes)
@@ -38,7 +43,7 @@ storiesOf('ChannelValue', module)
     <View style={{flex: 1, alignItems: 'center', justifyContent: 'center'}}>
       <ChannelValue
         value={text('value', text('value', '123'))}
-        icon={<Leaf width={40} height={40} fill={'#44cc44'}/>}
+        IconClass={WrappedIcon}
         units={text('units', 'hz')}
         prefix={boolean('prefix', false)}
         fontSize={number('fontSize', 20, { range: true, min: 1, max: 100, step: 1 })}

--- a/react-native/component-demo/storybook/stories/channel-value.tsx
+++ b/react-native/component-demo/storybook/stories/channel-value.tsx
@@ -5,7 +5,7 @@ import { ChannelValue } from '@pxblue/react-native-components';
 import { text, withKnobs, boolean, number, color } from '@storybook/addon-knobs';
 import Leaf from '@pxblue/icons-svg/leaf.svg';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
-import { wrapIcon } from '@pxblue/react-native-components/dist/icon-wrapper/icon-wrapper';
+import { wrapIcon } from '@pxblue/react-native-components';
 
 const notes = {
   notes: 'Any React Element may be passed in as `icon`; if using an svg, its color and size are not controlled by `ChannelValue`'

--- a/react-native/component-demo/storybook/stories/hero-banner.tsx
+++ b/react-native/component-demo/storybook/stories/hero-banner.tsx
@@ -9,8 +9,9 @@ import Ionicon from 'react-native-vector-icons/Ionicons';
 import MaterialCommunityIcon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { safeArea } from '../decorators';
 import { green, blue, gray, red } from '@pxblue/colors';
+import { wrapIcon } from '@pxblue/react-native-components/dist/icon-wrapper/icon-wrapper';
 
-const icon = <Leaf height={36} width={36} fill={'green'}/>;
+const ChartLineVariant = wrapIcon({ IconClass: MaterialCommunityIcon, name: 'chart-line-variant'})
 
 const heroes = [
   <Hero
@@ -35,7 +36,7 @@ const heroes = [
     label={'Loaded'}
     icon={<MaterialCommunityIcon name={'chart-pie'} size={36} color={blue[500]} />}
   >
-    <ChannelValue value={65} units={'%'} icon={<MaterialCommunityIcon name={'chart-line-variant'} size={12} color={red[500]} />} />
+    <ChannelValue value={65} units={'%'} IconClass={ChartLineVariant} />
   </Hero>,
   <Hero
     label={'Fifth item'}

--- a/react-native/component-demo/storybook/stories/hero-banner.tsx
+++ b/react-native/component-demo/storybook/stories/hero-banner.tsx
@@ -9,7 +9,7 @@ import Ionicon from 'react-native-vector-icons/Ionicons';
 import MaterialCommunityIcon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { safeArea } from '../decorators';
 import { green, blue, gray, red } from '@pxblue/colors';
-import { wrapIcon } from '@pxblue/react-native-components/dist/icon-wrapper/icon-wrapper';
+import { wrapIcon } from '@pxblue/react-native-components';
 
 const ChartLineVariant = wrapIcon({ IconClass: MaterialCommunityIcon, name: 'chart-line-variant'})
 

--- a/react-native/component-demo/storybook/stories/hero.tsx
+++ b/react-native/component-demo/storybook/stories/hero.tsx
@@ -5,7 +5,7 @@ import { centered } from '../decorators';
 import { Hero } from '@pxblue/react-native-components';
 import Leaf from '@pxblue/icons-svg/leaf.svg';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
-import { wrapIcon } from '@pxblue/react-native-components/dist/icon-wrapper/icon-wrapper';
+import { wrapIcon } from '@pxblue/react-native-components';
 
 const icon = <Leaf height={36} width={36} fill={'green'}/>;
 const Line = wrapIcon({ IconClass: Icon, name: 'chart-line-variant' });

--- a/react-native/component-demo/storybook/stories/hero.tsx
+++ b/react-native/component-demo/storybook/stories/hero.tsx
@@ -5,10 +5,11 @@ import { centered } from '../decorators';
 import { Hero } from '@pxblue/react-native-components';
 import Leaf from '@pxblue/icons-svg/leaf.svg';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
+import { wrapIcon } from '@pxblue/react-native-components/dist/icon-wrapper/icon-wrapper';
 
 const icon = <Leaf height={36} width={36} fill={'green'}/>;
-const cloud = <Icon name={'cloud-off-outline'} size={36} color={'blue'}/>;
-const line = <Icon name={'chart-line-variant'} size={12} color={'red'}/>;
+const Line = wrapIcon({ IconClass: Icon, name: 'chart-line-variant' });
+const Cloud = wrapIcon({ IconClass: Icon, name: 'cloud-off-outline' });
 
 storiesOf('Hero', module)
   .addDecorator(withKnobs)
@@ -30,9 +31,9 @@ storiesOf('Hero', module)
   .add('material icon with all props', () => (
     <Hero
       label={text('label', 'No Clouds')}
-      icon={cloud}
+      icon={Cloud}
       value={text('value', '100')}
       units={text('units', '°C')}
-      valueIcon={line}
+      ValueIconClass={Line}
     />
   ));

--- a/react-native/component-demo/storybook/stories/info-list-item/info-list-item.tsx
+++ b/react-native/component-demo/storybook/stories/info-list-item/info-list-item.tsx
@@ -4,7 +4,7 @@ import { InfoListItem } from '@pxblue/react-native-components';
 import { text, withKnobs, color } from '@storybook/addon-knobs';
 import Leaf from '@pxblue/icons-svg/leaf.svg';
 import { framedRow } from '../../decorators';
-import { wrapIcon } from '@pxblue/react-native-components/dist/icon-wrapper/icon-wrapper';
+import { wrapIcon } from '@pxblue/react-native-components';
 
 const notes = {
   notes: 'The borders are NOT part of the component; they are provided for framing only. Any React Element may be passed in as `icon`; if using an svg, its color and size are not controlled by `ChannelValue`'

--- a/react-native/component-demo/storybook/stories/info-list-item/info-list-item.tsx
+++ b/react-native/component-demo/storybook/stories/info-list-item/info-list-item.tsx
@@ -3,17 +3,14 @@ import { storiesOf } from '@storybook/react-native';
 import { InfoListItem } from '@pxblue/react-native-components';
 import { text, withKnobs, color } from '@storybook/addon-knobs';
 import Leaf from '@pxblue/icons-svg/leaf.svg';
-import Flow from '@pxblue/icons-svg/flow.svg';
-import Apple from '@pxblue/icons-svg/apple.svg';
-import { View, FlatList } from 'react-native';
-import { InfoListItemProps } from '@pxblue/react-native-components/dist/info-list-item/info-list-item';
-import { green, blue } from '@pxblue/colors';
-import * as _ from 'lodash';
 import { framedRow } from '../../decorators';
+import { wrapIcon } from '@pxblue/react-native-components/dist/icon-wrapper/icon-wrapper';
 
 const notes = {
   notes: 'The borders are NOT part of the component; they are provided for framing only. Any React Element may be passed in as `icon`; if using an svg, its color and size are not controlled by `ChannelValue`'
 };
+
+const LeafIcon = wrapIcon({ IconClass: Leaf });
 
 storiesOf('InfoListItem', module)
   .addDecorator(withKnobs)
@@ -27,7 +24,7 @@ storiesOf('InfoListItem', module)
   .add('with all props', () => (
     <InfoListItem
       title={text('title', 'Test')}
-      icon={<Leaf fill="#9944cc" width={24} height={24} />}
+      IconClass={LeafIcon}
       subtitle={text('subtitle', 'the subtitle can be text or a list of elements')}
       color={color('tabColor', '#4455cc')}
     />
@@ -35,7 +32,7 @@ storiesOf('InfoListItem', module)
   .add('with long text', () => (
     <InfoListItem
       title={text('title', 'This is a really really really really really really really really long title')}
-      icon={<Leaf fill="#9944cc" width={24} height={24} />}
+      IconClass={LeafIcon}
       subtitle={text('subtitle', 'this is a really really really really really really really really really really long subtitle')}
       color={color('tabColor', '#4455cc')}
     />
@@ -43,7 +40,7 @@ storiesOf('InfoListItem', module)
   .add('with long text and a chevron', () => (
     <InfoListItem
       title={text('title', 'This is a really really really really really really really really long title')}
-      icon={<Leaf fill="#9944cc" width={24} height={24} />}
+      IconClass={LeafIcon}
       subtitle={text('subtitle', 'this is a really really really really really really really really really really long subtitle')}
       color={color('tabColor', '#4455cc')}
       onPress={() => {}}
@@ -52,7 +49,7 @@ storiesOf('InfoListItem', module)
   .add('array for subtitles', () => (
     <InfoListItem
       title={text('title', 'Test')}
-      icon={<Leaf fill="#9944cc" width={24} height={24} />}
+      IconClass={LeafIcon}
       subtitle={['4', <Leaf width={12} height={12} />, 'leaves']}
       color={color('tabColor', '#4455cc')}
     />

--- a/react-native/component-demo/storybook/stories/info-list-item/info-list.tsx
+++ b/react-native/component-demo/storybook/stories/info-list-item/info-list.tsx
@@ -7,14 +7,17 @@ import Apple from '@pxblue/icons-svg/apple.svg';
 import { blue, green } from '@pxblue/colors';
 import * as _ from 'lodash';
 import { InfoListItemProps } from '@pxblue/react-native-components/dist/info-list-item/info-list-item';
+import { wrapIcon } from '@pxblue/react-native-components/dist/icon-wrapper/icon-wrapper';
 
 const Separator: React.FunctionComponent = () =>
   <View style={{ height: 1, marginLeft: 40, backgroundColor: '#cccccc' }} />
 
+const AppleIcon = wrapIcon({ IconClass: Apple });
+
 const createInfoListItemProps = (): InfoListItemProps => {
   let subtitle: InfoListItemProps['subtitle'];
   let color: InfoListItemProps['color'];
-  let icon: InfoListItemProps['icon'];
+  let IconClass: InfoListItemProps['IconClass'];
   let onPress: InfoListItemProps['onPress'];
 
   const subtitleNumber = Math.random();
@@ -34,7 +37,7 @@ const createInfoListItemProps = (): InfoListItemProps => {
   }
 
   if (Math.random() < 0.7) {
-    icon = <Apple width={24} height={24} fill={color || blue[700]} />;
+    IconClass = AppleIcon;
   }
 
   if (Math.random() < 0.5) {
@@ -45,7 +48,7 @@ const createInfoListItemProps = (): InfoListItemProps => {
     title: 'Title',
     subtitle,
     color,
-    icon,
+    IconClass,
     onPress
   }
 }

--- a/react-native/component-demo/storybook/stories/info-list-item/info-list.tsx
+++ b/react-native/component-demo/storybook/stories/info-list-item/info-list.tsx
@@ -7,7 +7,7 @@ import Apple from '@pxblue/icons-svg/apple.svg';
 import { blue, green } from '@pxblue/colors';
 import * as _ from 'lodash';
 import { InfoListItemProps } from '@pxblue/react-native-components/dist/info-list-item/info-list-item';
-import { wrapIcon } from '@pxblue/react-native-components/dist/icon-wrapper/icon-wrapper';
+import { wrapIcon } from '@pxblue/react-native-components';
 
 const Separator: React.FunctionComponent = () =>
   <View style={{ height: 1, marginLeft: 40, backgroundColor: '#cccccc' }} />

--- a/react-native/components/jest.config.js
+++ b/react-native/components/jest.config.js
@@ -1,6 +1,9 @@
 module.exports = {
   preset: 'react-native',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  moduleNameMapper: {
+    '\\.svg$': 'identity-obj-proxy'
+  },
   testRegex: 'src/.*(test|spec)\\.[jt]sx?$',
   transform: {
     "^.+\\.tsx?$": "ts-jest"

--- a/react-native/components/package.json
+++ b/react-native/components/package.json
@@ -24,6 +24,7 @@
     "react-native-vector-icons": "^6.6.0"
   },
   "devDependencies": {
+    "@pxblue/icons-svg": "^1.0.15",
     "@react-native-community/eslint-config": "^0.0.5",
     "@types/faker": "^4.1.5",
     "@types/jest": "^24.0.15",
@@ -36,7 +37,9 @@
     "@typescript-eslint/parser": "^1.13.0",
     "eslint": "^6.1.0",
     "faker": "^4.1.0",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^24.8.0",
+    "react-native-svg": "^9.6.1",
     "react-test-renderer": "^16.8.6",
     "ts-jest": "^24.0.2",
     "typescript": "^3.5.3"

--- a/react-native/components/src/channel-value/channel-value.test.tsx
+++ b/react-native/components/src/channel-value/channel-value.test.tsx
@@ -70,7 +70,7 @@ describe('ChannelValue', () => {
     const instance = TestRenderer.create(
       <ChannelValue
         value={123}
-        icon={<TouchableOpacity />}
+        IconClass={() => <TouchableOpacity />}
       />
     ).root;
 

--- a/react-native/components/src/channel-value/channel-value.tsx
+++ b/react-native/components/src/channel-value/channel-value.tsx
@@ -1,12 +1,13 @@
-import React, { Component } from 'react';
+import React, { Component, ComponentType } from 'react';
 import { Text, View, StyleSheet } from 'react-native';
+import { wrapIcon, IconType, GeneralIcon } from '../icon-wrapper/icon-wrapper';
 
 export interface ChannelValueProps {
   /** Value to show (bold text) */
   value: string | number;
 
-  /** Inline icon to display */
-  icon?: React.ReactNode;
+  /** Icon component to render */
+  IconClass?: ReturnType<typeof wrapIcon>;
 
   /** Text to show for units (light text) */
   units?: string;
@@ -29,11 +30,11 @@ export interface ChannelValueProps {
  */
 export class ChannelValue extends Component<ChannelValueProps> {
   public render() {
-    const { value, icon, fontSize, color } = this.props;
+    const { value, fontSize, color } = this.props;
 
     return (
       <View style={styles.row}>
-        {icon}
+        {this.icon()}
         <Text numberOfLines={1} ellipsizeMode={'tail'} testID={'text-wrapper'}>
           {this.prefixUnits()}
           <Text style={[styles.bold, { fontSize, color }]}>
@@ -43,6 +44,16 @@ export class ChannelValue extends Component<ChannelValueProps> {
         </Text>
       </View>
     );
+  }
+
+  private icon() {
+    const { color, IconClass } = this.props;
+
+    if (IconClass) {
+      return (
+        <IconClass size={18} color={color || 'black'} />
+      );
+    }
   }
 
   private prefixUnits() {

--- a/react-native/components/src/channel-value/channel-value.tsx
+++ b/react-native/components/src/channel-value/channel-value.tsx
@@ -1,13 +1,12 @@
 import React, { Component, ComponentType } from 'react';
 import { Text, View, StyleSheet } from 'react-native';
-import { wrapIcon, IconType, GeneralIcon } from '../icon-wrapper/icon-wrapper';
 
 export interface ChannelValueProps {
   /** Value to show (bold text) */
   value: string | number;
 
   /** Icon component to render */
-  IconClass?: ReturnType<typeof wrapIcon>;
+  IconClass?: ComponentType<{ size: number, color: string }>
 
   /** Text to show for units (light text) */
   units?: string;

--- a/react-native/components/src/helpers/utils.test.ts
+++ b/react-native/components/src/helpers/utils.test.ts
@@ -1,4 +1,4 @@
-import { interleave } from "./utils";
+import { interleave } from './utils';
 
 describe('utils', () => {
   describe('interleave', () => {

--- a/react-native/components/src/hero/hero.test.tsx
+++ b/react-native/components/src/hero/hero.test.tsx
@@ -29,7 +29,7 @@ describe('Hero', () => {
     let instance: ReactTestInstance;
     beforeEach(() => {
       instance = TestRenderer.create(
-        <Hero label={'Hero'} icon={<View/>} value={'100'} valueIcon={<View/>} units={'%'} onPress={jest.fn()}/>
+        <Hero label={'Hero'} icon={<View/>} value={'100'} units={'%'} onPress={jest.fn()}/>
       ).root;
     });
 

--- a/react-native/components/src/hero/hero.tsx
+++ b/react-native/components/src/hero/hero.tsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { ChannelValue } from '../channel-value';
 import * as Colors from '@pxblue/colors';
+import { wrapIcon } from '../icon-wrapper/icon-wrapper';
 
 export interface HeroProps {
   /** Label to show */
@@ -13,8 +14,8 @@ export interface HeroProps {
   /** Value for ChannelValue child */
   value?: number | string;
 
-  /** Icon for ChannelValue child */
-  valueIcon?: React.ReactNode;
+  /** Icon component for ChannelValue child */
+  ValueIconClass?: ReturnType<typeof wrapIcon>;
 
   /** Units for value of ChannelValue child */
   units?: string;
@@ -32,7 +33,7 @@ export interface HeroProps {
  */
 export class Hero extends Component<HeroProps> {
   public render() {
-    const {label, icon, value, valueIcon, units, onPress, children} = this.props;
+    const {label, icon, value, ValueIconClass, units, onPress, children} = this.props;
     return (
       <TouchableOpacity onPress={onPress} disabled={!onPress} style={styles.wrapper}>
         <View style={styles.icon}>
@@ -40,7 +41,7 @@ export class Hero extends Component<HeroProps> {
         </View>
         <View style={styles.values}>
           {!children && !!value &&
-            <ChannelValue value={value} units={units} icon={valueIcon}/>
+            <ChannelValue value={value} units={units} IconClass={ValueIconClass}/>
           }
           {children}
         </View>

--- a/react-native/components/src/icon-wrapper/icon-wrapper.test.tsx
+++ b/react-native/components/src/icon-wrapper/icon-wrapper.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+import { wrapIcon } from './icon-wrapper';
+import { View } from 'react-native';
+import { SvgProps } from 'react-native-svg';
+import { IconProps } from 'react-native-vector-icons/Icon';
+
+const Icon = (props: IconProps) =>
+  <View />
+
+const Leaf = (props: SvgProps) =>
+  <View />
+
+describe('IconWrapper', () => {
+  describe('when passed a MaterialCommunity icon', () => {
+    it('passes through the size and color', () => {
+      const WrappedIcon = wrapIcon({ IconClass: Icon, name: 'chart-pie' });
+      const instance = TestRenderer.create(
+        <WrappedIcon size={100} color={'red'} />
+      ).root;
+
+      const icon = instance.find(x => x.props.testID === 'icon');
+
+      expect(icon.props).toMatchObject({
+        size: 100,
+        color: 'red',
+        name: 'chart-pie'
+      });
+    });
+  });
+
+  describe('when passed a pxblue svg icon', () => {
+    it('converts size and color to height, width, and fill', () => {
+      const WrappedLeaf = wrapIcon({ IconClass: Leaf });
+      const instance = TestRenderer.create(
+        <WrappedLeaf size={100} color={'red'} />
+      ).root;
+
+      const icon = instance.find(x => x.props.testID === 'icon');
+
+      expect(icon.props).toMatchObject({
+        width: 100,
+        height: 100,
+        fill: 'red'
+      });
+    });
+  });
+});

--- a/react-native/components/src/icon-wrapper/icon-wrapper.tsx
+++ b/react-native/components/src/icon-wrapper/icon-wrapper.tsx
@@ -2,10 +2,6 @@ import React, { ComponentType, Component } from 'react';
 import { SvgProps } from 'react-native-svg';
 import { IconProps } from 'react-native-vector-icons/Icon';
 
-import Leaf from '@pxblue/icons-svg/leaf.svg';
-import Flow from '@pxblue/icons-svg/flow.svg';
-import MaterialCommunityIcon from 'react-native-vector-icons/MaterialCommunityIcons';
-
 interface IconSetArg {
   IconClass: ComponentType<IconProps>;
   name: string;
@@ -33,35 +29,3 @@ export const wrapIcon = (arg: IconArg) => {
       );
     }
   };
-
-export enum IconType {
-  PxBlue = 'PX_BLUE',
-  MaterialCommunityIcons = 'MATERIAL_COMMUNIT_ICONS',
-  Ionicon = 'IONICON',
-}
-
-export interface Props {
-  type: IconType;
-  name: string;
-  color: string;
-  size: number;
-}
-export class GeneralIcon extends Component<Props> {
-  public render() {
-    const { type, name, size, color } = this.props;
-
-    switch(type) {
-      case IconType.PxBlue:
-        switch (name) {
-          case 'flow':
-            return <Flow fill={color} width={size} height={size} />
-          case 'leaf':
-            return <Leaf fill={color} width={size} height={size} />
-        }
-      case IconType.MaterialCommunityIcons:
-        return (
-          <MaterialCommunityIcon name={name} size={size} color={color} />
-        )
-    }
-  }
-}

--- a/react-native/components/src/icon-wrapper/icon-wrapper.tsx
+++ b/react-native/components/src/icon-wrapper/icon-wrapper.tsx
@@ -1,0 +1,67 @@
+import React, { ComponentType, Component } from 'react';
+import { SvgProps } from 'react-native-svg';
+import { IconProps } from 'react-native-vector-icons/Icon';
+
+import Leaf from '@pxblue/icons-svg/leaf.svg';
+import Flow from '@pxblue/icons-svg/flow.svg';
+import MaterialCommunityIcon from 'react-native-vector-icons/MaterialCommunityIcons';
+
+interface IconSetArg {
+  IconClass: ComponentType<IconProps>;
+  name: string;
+};
+
+interface PxBlueIconArg {
+  IconClass: ComponentType<SvgProps>;
+}
+
+type IconArg = IconSetArg | PxBlueIconArg;
+
+const isIconSetArg = (x: IconSetArg | PxBlueIconArg): x is IconSetArg =>
+  (x as any).name !== undefined;
+
+export const wrapIcon = (arg: IconArg) => {
+    if (isIconSetArg(arg)) {
+      const { name,  IconClass } = arg;
+      return (props: { size: number, color: string }) => (
+        <IconClass name={name} color={props.color} size={props.size} testID={'icon'} />
+      );
+    } else {
+      const { IconClass } = arg;
+      return (props: { size: number, color: string }) => (
+        <IconClass fill={props.color} width={props.size} height={props.size} testID={'icon'} />
+      );
+    }
+  };
+
+export enum IconType {
+  PxBlue = 'PX_BLUE',
+  MaterialCommunityIcons = 'MATERIAL_COMMUNIT_ICONS',
+  Ionicon = 'IONICON',
+}
+
+export interface Props {
+  type: IconType;
+  name: string;
+  color: string;
+  size: number;
+}
+export class GeneralIcon extends Component<Props> {
+  public render() {
+    const { type, name, size, color } = this.props;
+
+    switch(type) {
+      case IconType.PxBlue:
+        switch (name) {
+          case 'flow':
+            return <Flow fill={color} width={size} height={size} />
+          case 'leaf':
+            return <Leaf fill={color} width={size} height={size} />
+        }
+      case IconType.MaterialCommunityIcons:
+        return (
+          <MaterialCommunityIcon name={name} size={size} color={color} />
+        )
+    }
+  }
+}

--- a/react-native/components/src/index.ts
+++ b/react-native/components/src/index.ts
@@ -5,6 +5,7 @@ import { Hero } from './hero';
 import { HeroBanner } from './hero-banner';
 import { InfoListItem } from './info-list-item';
 import { LayoutView } from './layout-view';
+import { wrapIcon } from './icon-wrapper/icon-wrapper';
 
 export {
   ChannelValue,
@@ -13,5 +14,6 @@ export {
   Hero,
   HeroBanner,
   InfoListItem,
-  LayoutView
+  LayoutView,
+  wrapIcon
 };

--- a/react-native/components/src/info-list-item/info-list-item.tsx
+++ b/react-native/components/src/info-list-item/info-list-item.tsx
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component, Fragment, ComponentType } from 'react';
 import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import * as Colors from '@pxblue/colors';
@@ -11,8 +11,8 @@ export interface InfoListItemProps {
   /** Subtitle. If an array, will be separated by dots. */
   subtitle?: string | Array<React.ReactNode>;
 
-  /** Icon to render. If provided, its color and size should be set */
-  icon?: React.ReactNode;
+  /** Component to render to the left of the title */
+  IconClass?: ComponentType<{ size: number, color: string }>;
 
   /** Color to use for title and tab on left side */
   color?: string;
@@ -25,7 +25,7 @@ export class InfoListItem extends Component<InfoListItemProps> {
   private static readonly MAX_SUBTITLE_ELEMENTS = 3;
 
   public render() {
-    const { title, icon, color, onPress } = this.props;
+    const { title, color, onPress } = this.props;
     const { bigText, fixedHeight, row, fullHeight, tab, iconContainer, contentContainer, withMargins, withRightPadding } = styles;
     const titleColor = color || Colors.gray[800];
 
@@ -33,7 +33,7 @@ export class InfoListItem extends Component<InfoListItemProps> {
       <TouchableOpacity onPress={onPress} style={[fixedHeight, row, withRightPadding]} disabled={!onPress}>
         <View style={[fullHeight, tab, { backgroundColor: color }]} />
         <View style={[iconContainer, withMargins]}>
-          {icon}
+          {this.icon()}
         </View>
         <View style={contentContainer}>
           <Text style={[bigText, { color: titleColor }]} numberOfLines={1} ellipsizeMode={'tail'}>
@@ -46,6 +46,16 @@ export class InfoListItem extends Component<InfoListItemProps> {
         {this.chevron()}
       </TouchableOpacity>
     );
+  }
+
+  private icon() {
+    const { IconClass, color } = this.props;
+
+    if (IconClass) {
+      return (
+        <IconClass size={24} color={color || Colors.gray[800]} />
+      );
+    }
   }
 
   private chevron() {

--- a/react-native/components/types/svg.d.ts
+++ b/react-native/components/types/svg.d.ts
@@ -1,0 +1,5 @@
+declare module '*.svg' {
+  import { SvgProps } from 'react-native-svg'
+  const content: React.ComponentClass<SvgProps, any>;
+  export default content
+}

--- a/react-native/components/yarn.lock
+++ b/react-native/components/yarn.lock
@@ -845,6 +845,11 @@
   resolved "https://registry.yarnpkg.com/@pxblue/colors/-/colors-1.0.13.tgz#1ed76734267f77dd4b390836f61d01439fc35132"
   integrity sha512-tneNNYclHmNNIbo6J7XXEumoJZLBXqeO2LFufWxRvIs5yeVVfaJN3zWREl1oo5KP67aDixYgEKB7LH0oeTL+lQ==
 
+"@pxblue/icons-svg@^1.0.15":
+  version "1.0.15"
+  resolved "https://registry.yarnpkg.com/@pxblue/icons-svg/-/icons-svg-1.0.15.tgz#04c1a08f9f7cb587ea9a4f44d905d87fd405fbfb"
+  integrity sha512-3hZm7NFTK9Zm/LZKhS5MoUhOthPUizXFwRywGzEB/YvPQxMzSqLmh3oxbtfHcopVkxJQ3bNSwT+eOLwlcxbKmw==
+
 "@react-native-community/cli-platform-android@^2.0.1", "@react-native-community/cli-platform-android@^2.7.0":
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-2.7.0.tgz#511d1db12c52d29cb87b6e4e84d63030ffa2c38d"
@@ -2915,6 +2920,11 @@ har-validator@~5.1.0:
     ajv "^6.5.5"
     har-schema "^2.0.0"
 
+harmony-reflect@^1.4.6:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/harmony-reflect/-/harmony-reflect-1.6.1.tgz#c108d4f2bb451efef7a37861fdbdae72c9bdefa9"
+  integrity sha512-WJTeyp0JzGtHcuMsi7rw2VwtkvLa+JyfEKJCFyfcS0+CDkjQ5lHPu7zEhFZP+PDSRrEgXa5Ah0l1MbgbE41XjA==
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -3011,6 +3021,13 @@ iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@^0.4.4, ic
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+identity-obj-proxy@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz#94d2bda96084453ef36fbc5aaec37e0f79f1fc14"
+  integrity sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=
+  dependencies:
+    harmony-reflect "^1.4.6"
 
 ignore-walk@^3.0.1:
   version "3.0.1"
@@ -5205,6 +5222,11 @@ react-native-status-bar-height@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/react-native-status-bar-height/-/react-native-status-bar-height-2.3.1.tgz#b92ce9112c2367290847ac11284d9d84a6330169"
   integrity sha512-m9nGKYfFn6ljF1abafzF5cFaD9JCzXwj7kNE9CuF+g0TgtItH70eY2uHaCV9moENTftqd5XIS3Cx0mf4WfistA==
+  
+react-native-svg@^9.6.1:
+  version "9.6.1"
+  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-9.6.1.tgz#4d2ba1e7ecd78d06603e8bf2fbc5072fc5852506"
+  integrity sha512-X8WvZ5uNHyE+17Q4SSbdQZ1NsRyRxdvAFqipqDldL6D0oUB0pBI2tekx03N4taVtVN+p8Pg3T3SSmIxwXZmMYA==
 
 react-native-vector-icons@^6.6.0:
   version "6.6.0"

--- a/react-native/docs/channel-value.md
+++ b/react-native/docs/channel-value.md
@@ -2,22 +2,29 @@
 
 The ChannelValue component is used to display...a channel value (and units). This component abstracts the styles used to display the channel and units as well as an optional inline icon. These are used as part of the [Hero](./Hero.md) component, but can also be used inline (e.g., in a list)
 
+Note: If provided, the IconClass must be a React.ComponentClass or React.FunctionComponent with props of `{ size: number, color: string }`. This library exposes a `wrapIcon` higher-order function that can convert components from `react-native-vector-icons` or from `@pxblue/icons-svg` to this format.
+
 <img alt="Sample Channel Value" src="./images/leaf-count.png">
 
 ## Example
 ```
 import { ChannelValue } from '@pxblue/react-native-components';
+import Leaf from '@pxblue/icons-svg/leaf.svg';
+
+const WrappedLeaf = wrapIcon({ IconClass: Leaf });
+
 ...
-<ChannelValue value={100} units={'%'} icon={<Icon />} />
+
+<ChannelValue value={100} units={'%'} IconClass={<WrappedLeaf />} />
 ```
 
 ## Props
 
-| Name     | Type            | Required | Default | Examples           |
-|----------|-----------------|----------|---------|--------------------|
-| value    | string | number | yes      |         | 123, 'on'          |
-| icon     | React.ReactNode | no       |         | <MyIcon />         |
-| units    | string          | no       |         | 'hz', '$'          |
-| prefix   | boolean         | no       | false   | true, false        |
-| fontSize | number          | no       | 20      | 12, 30             |
-| color    | string          | no       | 'black' | 'black', '#000000' |
+| Name      | Type                                             | Required | Default | Examples              |
+|-----------|--------------------------------------------------|----------|---------|-----------------------|
+| value     | string &vert; number                             | yes      |         | 123, 'on'             |
+| IconClass | React.Component<{ size: number, color: string }> | no       |         | &lt;WrappedLeaf /&gt; |
+| units     | string                                           | no       |         | 'hz', '$'             |
+| prefix    | boolean                                          | no       | false   | true, false           |
+| fontSize  | number                                           | no       | 20      | 12, 30                |
+| color     | string                                           | no       | 'black' | 'black', '#000000'    |

--- a/react-native/docs/icon-wrapper.md
+++ b/react-native/docs/icon-wrapper.md
@@ -1,0 +1,27 @@
+# wrapIcon
+
+Some components in this library allow for an IconClass to be passed in. This allows the icon to be parameterized while allowing the library component to control the icon's size and color. IconClasses are expected to be of the type `React.ComponentType<{ size: number, color: string }>`.
+
+However, the recommended icon libraries, `@pxblue/icons-svg` and `react-native-vector-icons`, do not not conform to this shape. Therefore, this library exports `wrapIcon` a Higher Order Component to convert them.
+
+## Use with `@pxblue/icons-svg`
+
+```
+import Leaf from '@pxblue/icons-svg/leaf.svg';
+
+const LeafIcon = wrapIcon({ IconClass: Leaf });
+```
+
+## Use with `react-native-vector-icons`
+
+Icons from `react-native-vector-icons` require a name. See their documentation for which names work each Icon set.
+
+```
+import MaterialCommunityIcon from 'react-native-vector-icons/MaterialCommunityIcons';
+
+const Cloud = wrapIcon({ IconClass: MaterialCommunityIcon, name: 'cloud-off-outline' });
+```
+
+## Caveats
+
+As with all Higher Order Components, there is a performance hit if the function is called from another component's `render` method. It is therefore advised to always call `wrapIcon` once per Icon type, and to do so outside of any methods.

--- a/react-native/docs/info-list-item.md
+++ b/react-native/docs/info-list-item.md
@@ -2,11 +2,19 @@
 
 Component to be used in list views. It positions a title, as well as optional subtitles, icons, and tab on side.
 
+Note: If provided, the IconClass must be a React.ComponentClass or React.FunctionComponent with props of `{ size: number, color: string }`. This library exposes a `wrapIcon` higher-order function that can convert components from `react-native-vector-icons` or from `@pxblue/icons-svg` to this format.
+
 ## Example
 ```
+import Leaf from '@pxblue/icons-svg/leaf.svg';
+
+const WrappedLeaf = wrapIcon({ IconClass: Leaf });
+
+...
+
 <InfoListItem
   title={text('title', 'Test')}
-  icon={<Leaf fill="#9944cc" width={24} height={24} />}
+  IconClass={<WrappedLeaf />}
   subtitle={text('subtitle', 'the subtitle can be text or a list of elements')}
   color={color('tabColor', '#4455cc')}
 />
@@ -14,11 +22,11 @@ Component to be used in list views. It positions a title, as well as optional su
 
 ## Props
 
-| Name     | Type            | Required | Default | Examples           |
-|----------|-----------------|----------|---------|--------------------|
-| value    | string | number | yes      |         | 123, 'on'          |
-| icon     | React.ReactNode | no       |         | <MyIcon />         |
-| units    | string          | no       |         | 'hz', '$'          |
-| prefix   | boolean         | no       | false   | true, false        |
-| fontSize | number          | no       | 20      | 12, 30             |
-| color    | string          | no       | 'black' | 'black', '#000000' |
+| Name      | Type                                                       | Required | Default | Examples           |
+|-----------|------------------------------------------------------------|----------|---------|--------------------|
+| value     | string &vert; number                                       | yes      |         | 123, 'on'          |
+| IconClass | React.ComponentType&lt;{ size: number, color: string }&gt; | no       |         | &lt;MyIcon /&gt;   |
+| units     | string                                                     | no       |         | 'hz', '$'          |
+| prefix    | boolean                                                    | no       | false   | true, false        |
+| fontSize  | number                                                     | no       | 20      | 12, 30             |
+| color     | string                                                     | no       | 'black' | 'black', '#000000' |


### PR DESCRIPTION
Changes proposed in this Pull Request:
- Adds `wrapIcon` HOC to create consistent abstraction over `@pxblue/icons-svg` and `react-native-vector-icons`
- Switch from taking `icon` to taking `IconClass` in `ChannelValue` and `InfoListItem`
 