### PR TITLE
Change header color to white when searching.

### DIFF
--- a/react-native/component-demo/storybook/index.tsx
+++ b/react-native/component-demo/storybook/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { configure, getStorybookUI } from '@storybook/react-native';
 import './rn-addons';
 import { ThemeProvider } from '@pxblue/react-native-components';
-import { gray, white, blue, red, green } from '@pxblue/colors';
+import { gray, white, blue, red, green, black } from '@pxblue/colors';
 
 // import stories
 configure(() => {
@@ -29,7 +29,7 @@ const ThemedStorybook = () =>
         fontWeight: '400'
       },
       light: {
-        fontFamily: 'Beth Ellen',
+        fontFamily: 'Open Sans',
         fontWeight: '300'
       },
       thin: {
@@ -43,8 +43,8 @@ const ThemedStorybook = () =>
       surface: white[200],
       accent: blue[700],
       error: red[500],
-      text: gray[600],
-      onPrimary: white[200]
+      text: black[500],
+      onPrimary: white[500]
     },
     sizes: {
       small: 12,

--- a/react-native/components/src/header/header.tsx
+++ b/react-native/components/src/header/header.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react-native';
 import { getStatusBarHeight } from 'react-native-status-bar-height';
 import Icon from 'react-native-vector-icons/MaterialIcons';
-import { blue, white } from '@pxblue/colors';
+import { black, blue, white } from '@pxblue/colors';
 import color from 'color';
 import createAnimatedComponent = Animated.createAnimatedComponent;
 import { withTheme, Theme, WithTheme } from '../theme';
@@ -350,13 +350,24 @@ class HeaderClass extends Component<WithTheme<HeaderProps>, HeaderState> {
 
   private fontColor() {
     const { fontColor, theme } = this.props;
+    const { searching } = this.state;
 
-    return fontColor || theme.colors.onPrimary;
+    if (searching) {
+      return theme.colors.text;
+    } else {
+      return fontColor || theme.colors.onPrimary;
+    }
   }
 
   private backgroundColor() {
     const { backgroundColor, theme } = this.props;
-    return backgroundColor || theme.colors.primary;
+    const { searching } = this.state;
+
+    if (searching) {
+      return theme.colors.background;
+    } else {
+      return backgroundColor || theme.colors.primary;
+    }
   }
 
   private onPressSearch() {


### PR DESCRIPTION
Changes proposed in this Pull Request:
- When searching using the `Header`, the background color changes to white, and the text color changes to black (or whatever `theme.colors.background` and `theme.colors.text` are, respectively)
