### PR TITLE
Fix Open Sans font issue - fix is in the @pxblue/themes package

### DIFF
--- a/reactnative/component-demo/demo.js
+++ b/reactnative/component-demo/demo.js
@@ -22,6 +22,7 @@ import _Humidity from '@pxblue/icons-svg/moisture';
 import _Battery from '@pxblue/icons-svg/battery.svg';
 
 import * as PXBColors from '@pxblue/colors';
+import { ReactNativeThemes } from '@pxblue/themes';
 const backgroundImage = require('./storybook/assets/farm.jpg');
 
 const ChartLineVariant = wrapIcon({ IconClass: MaterialCommunityIcon, name: 'chart-line-variant' })
@@ -40,7 +41,7 @@ const PADDING = 10;
 export default class App extends React.Component {
     render() {
         return (
-            <ThemeProvider>
+            <ThemeProvider theme={ReactNativeThemes.blue}>
                 <View style={{ flex: 1, backgroundColor: PXBColors.gray[50] }}>
                     <Header
                         expandable={true}

--- a/reactnative/component-demo/package.json
+++ b/reactnative/component-demo/package.json
@@ -14,6 +14,7 @@
     "@pxblue/colors": "^1.0.13",
     "@pxblue/icons-svg": "^1.0.15",
     "@pxblue/react-native-components": "latest",
+    "@pxblue/themes": "^2.2.3",
     "color": "^3.1.2",
     "faker": "^4.1.0",
     "react": "16.9.0",

--- a/reactnative/component-demo/storybook/index.tsx
+++ b/reactnative/component-demo/storybook/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { getStorybookUI, configure } from '@storybook/react-native';
 import { ThemeProvider } from '@pxblue/react-native-components';
-import { blue, gray, white, red, lightBlue } from '@pxblue/colors';
-
+import { ReactNativeThemes } from '@pxblue/themes';
 import './rn-addons';
 
 // import stories
@@ -15,51 +14,8 @@ configure(() => {
 const StorybookUIRoot = getStorybookUI({});
 
 const ThemedStorybook = () => (
-  // This is the PX Blue theme
-  <ThemeProvider theme={{
-      roundness: 4,
-      fonts: {
-        extraBold: {
-          fontFamily: 'Open Sans',
-          fontWeight: '800'
-        },
-        bold: {
-          fontFamily: 'Open Sans',
-          fontWeight: '700'
-        },
-        semiBold: {
-          fontFamily: 'Open Sans',
-          fontWeight: '600'
-        },
-        regular: {
-          fontFamily: 'Open Sans',
-          fontWeight: '400'
-        },
-        light: {
-          fontFamily: 'Open Sans',
-          fontWeight: '300'
-        }
-      },
-      colors: {
-        primary: blue[500],
-        background: gray[50],
-        surface: white[50],
-        accent: lightBlue[500],
-        error: red[500],
-        text: gray[500],
-        onPrimary: white[50]
-      },
-      sizes: {
-        tiny: 10,
-        extraSmall: 12,
-        small: 14,
-        medium: 16,
-        large: 20,
-        extraLarge: 24,
-        giant: 34
-      }
-    }} >
-    <StorybookUIRoot/>
+  <ThemeProvider theme={ReactNativeThemes.blue}>
+    <StorybookUIRoot />
   </ThemeProvider>
 );
 

--- a/reactnative/component-demo/yarn.lock
+++ b/reactnative/component-demo/yarn.lock
@@ -1006,6 +1006,14 @@
     react-native-keyboard-aware-scroll-view "^0.8.0"
     react-native-status-bar-height "^2.3.1"
 
+"@pxblue/themes@^2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@pxblue/themes/-/themes-2.2.3.tgz#2bfe06dbfa0c2d0ae8f82f5516a30df665aa291c"
+  integrity sha512-CNKleocaCqALkVQKw+s2Kuoc1wLndJ42xR42+dbSbd9/4m2D9KboY82rdpVi9LPK9cJmZ0EQ/EfueGti8U9xlQ==
+  dependencies:
+    "@pxblue/colors" "^1.0.13"
+    typeface-open-sans "^0.0.54"
+
 "@reach/router@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.2.1.tgz#34ae3541a5ac44fa7796e5506a5d7274a162be4e"
@@ -7628,6 +7636,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typeface-open-sans@^0.0.54:
+  version "0.0.54"
+  resolved "https://registry.yarnpkg.com/typeface-open-sans/-/typeface-open-sans-0.0.54.tgz#20f5b5ea5c7f95d89dc1f8b2d2b1457680129cee"
+  integrity sha512-w6wOd6EicZdZKf0jSU/K3EzEi3zFgvWQSN7NOpRIQI5KeMWmC5Pg/lqtBVJHB0pRChYRmLdhf4h8ROur0A3JZQ==
 
 typescript@^3.6.3:
   version "3.6.3"


### PR DESCRIPTION
Fixes the issue "Open Sans is not a valid font"

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- imported the PX Blue react native theme file
- updated @pxblue/themes to replace the inline themes
- added theme to the showcase demo
