### PR TITLE
Fix PropTypes definitions throwing warnings in TS project

### DIFF
--- a/react/components/src/EmptyState/EmptyState.js
+++ b/react/components/src/EmptyState/EmptyState.js
@@ -32,7 +32,8 @@ EmptyState.propTypes = {
   title: PropTypes.string.isRequired,
   description: PropTypes.string,
   icon: PropTypes.element,
-  actions: PropTypes.element
+  actions: PropTypes.element,
+  iconStyles: PropTypes.object,
 };
 EmptyState.defaultProps = {};
 

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pxblue/react-components",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "React components for PX Blue applications",
   "scripts": {
     "test": "cd components && yarn test",


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes an issue where typescript projects using EmptyState react component would throw a warning in the console about incorrect prop-types for iconStyles .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Include the iconStyles in PropTypes definitions
