### PR TITLE
Implement custom element to left of InfoListItem text

### DIFF
--- a/react/component-demo/storybook/stories/info-list-item.stories.tsx
+++ b/react/component-demo/storybook/stories/info-list-item.stories.tsx
@@ -78,6 +78,15 @@ stories.add('with custom control', () => {
         rightComponent={<ChannelValue value={text('value', '15')} units={text('units', 'A')} />}
     />
 });
+stories.add('with custom leftComponent', () => {
+    return <InfoListItem dense
+        title={text('title', 'Test')}
+        divider={boolean('divider', true) ? 'full' : undefined}
+        hidePadding={boolean('hidePadding', true)}
+        icon={<Device />}
+        leftComponent={<ChannelValue value={text('value', '15')} units={text('units', 'A')} />}
+    />
+});
 stories.add('in a full list', () => {
     return (
         <List style={{ color: PXBColors.gray['800'], padding: 0 }}>

--- a/react/components/src/InfoListItem/InfoListItem.js
+++ b/react/components/src/InfoListItem/InfoListItem.js
@@ -23,12 +23,14 @@ const MAX_SUBTITLE_ELEMENTS = 6;
 
 class InfoListItemClass extends React.Component {
     render() {
-        const { classes, fontColor, onClick, statusColor, title, divider, dense } = this.props;
+        const { classes, fontColor, leftComponent, onClick, statusColor, title, divider, dense } = this.props;
         return (
             <ListItem style={this.wrapperStyle()} onClick={onClick ? () => onClick() : null} dense={dense}>
                 <div className={classes.statusStripe} style={{ backgroundColor: statusColor }}></div>
                 {(this.props.icon || !this.props.hidePadding) && this.icon()}
+                {leftComponent}
                 <ListItemText
+                    style={leftComponent ? { marginLeft: 16 } : {}}
                     primary={title}
                     secondary={this.subtitle()}
                     primaryTypographyProps={{ noWrap: true, variant: 'body1', className: classes.title, style: { color: fontColor || 'inherit' } }}
@@ -62,7 +64,7 @@ class InfoListItemClass extends React.Component {
         else if (!hidePadding) {
             return (
                 <ListItemAvatar>
-                    <Avatar style={{ backgroundColor: 'transparent' }}/>
+                    <Avatar style={{ backgroundColor: 'transparent' }} />
                 </ListItemAvatar>
             );
         }
@@ -131,6 +133,7 @@ InfoListItemClass.propTypes = {
     hidePadding: PropTypes.bool,
     icon: PropTypes.element,
     iconColor: PropTypes.string,
+    leftComponent: PropTypes.element,
     onClick: PropTypes.func,
     rightComponent: PropTypes.element,
     statusColor: PropTypes.string,

--- a/react/components/src/InfoListItem/InfoListItem.test.js
+++ b/react/components/src/InfoListItem/InfoListItem.test.js
@@ -110,6 +110,12 @@ describe("InfoListItem", () => {
         expect(wrapper.find(Chevron).length).toEqual(0);
         expect(wrapper.find(PersonIcon).length).toEqual(1);
     });
+    it('renders leftComponent', () => {
+        let wrapper = shallow(
+            <InfoListItem title="Test" leftComponent={<PersonIcon/>}/>
+        );
+        expect(wrapper.find(PersonIcon).length).toEqual(1);
+    });
 })
 
 

--- a/react/docs/InfoListItem.md
+++ b/react/docs/InfoListItem.md
@@ -29,6 +29,7 @@ import * as Colors from '@pxblue/colors';
 | hidePadding       | Remove left padding if no icon is used  | `boolean`                                          | no       | false               |                                         |
 | icon              | A component to render for the icon      | `React.Component`                                  | no       |                     | `<Leaf color={'inherit'} />`            |
 | iconColor         | Color override for the row icon         | `string`                                           | no       |                     |                                         |
+| leftComponent     | Component to render on the left side    | `React.Component`                                  | no       |                     | `<ListItemText/>`                       |
 | onClick           | A function to execute when clicked      | `function`                                         | no       |                     | `() => console.log('pressed')`          |
 | rightComponent    | Component to render on the right side   | `React.Component`                                  | no       |                     | `<ChannelValue/>`                       |
 | statusColor       | Status stripe and icon color            | `string`                                           | no       |                     | '#ff3333', 'orange'                     |


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #69. This feature is needed for WAS in order to have Timestamps for the events list.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Allow users to inject custom content to the left of the ListItemText in InfoListItem
- Update unit tests
- Update storybook
