### PR TITLE
Have Drawer extend from MUI Drawer props

### DIFF
--- a/react/components/src/Drawer/Drawer.tsx
+++ b/react/components/src/Drawer/Drawer.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { StyleRules, Theme, WithStyles, withStyles, WithTheme } from '@material-ui/core/styles';
-import { Drawer } from '@material-ui/core';
+import {Drawer, DrawerProps} from '@material-ui/core';
 import Hidden from '@material-ui/core/Hidden';
 
 type DrawerComponentProps = {
     open: boolean;
     width?: number;
 } & WithStyles &
-    WithTheme;
+    WithTheme &
+    Omit<DrawerProps, "translate">;
 
 type DrawerComponentState = {
     backdropClicked: boolean;


### PR DESCRIPTION

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Make Drawer props extend from MUI Drawer