### PR TITLE
Add configurable item dividers

### DIFF
--- a/react/components/src/core/Drawer/DrawerNavGroup.tsx
+++ b/react/components/src/core/Drawer/DrawerNavGroup.tsx
@@ -58,6 +58,7 @@ export type NavItem = {
     statusColor?: string;
     subtitle?: string;
     title: string;
+    divider?: boolean;
 };
 
 export type DrawerNavGroupProps = {
@@ -74,10 +75,12 @@ export type DrawerNavGroupProps = {
     open?: boolean;
     title?: string;
     titleColor?: string;
+    divider?: boolean;
 };
 
 function NavigationListItem(item: NavItem, props: DrawerNavGroupProps): ReactNode {
     const { title, subtitle, icon, statusColor, onClick, active } = item;
+    const { divider = true } = props;
     if (!title && !icon) {
         return null;
     }
@@ -109,7 +112,7 @@ function NavigationListItem(item: NavItem, props: DrawerNavGroupProps): ReactNod
                 dense
                 title={title}
                 subtitle={subtitle}
-                divider={'full'}
+                divider={item.divider === undefined ? (divider ? 'full' : undefined) : (item.divider ? 'full' : undefined)}
                 statusColor={statusColor}
                 fontColor={active ? activeFontColor : fontColor}
                 icon={icon}
@@ -151,7 +154,6 @@ export const DrawerNavGroup: React.FC<DrawerNavGroupProps> = (props) => {
                     <div key={`${title}_item_${index}`}>{NavigationListItem(item, props)}</div>
                 ))}
             </List>
-            <Divider />
         </>
     );
 };

--- a/react/components/tsconfig.json
+++ b/react/components/tsconfig.json
@@ -12,6 +12,6 @@
         "strictNullChecks": false,
     },
     "include": [
-        "src/index.ts"
+        "src/"
     ]
 }

--- a/react/demos/storybook/stories/drawer.stories.tsx
+++ b/react/demos/storybook/stories/drawer.stories.tsx
@@ -164,6 +164,7 @@ stories.add(
         const bodyActiveIconColor = color('activeIconColor', Colors.blue[500], bodyGroupId);
         const bodyActiveBackgroundColor = color('activeBackgroundColor', Colors.blue[50], bodyGroupId);
         const bodyChevron = boolean('chevron', false, bodyGroupId);
+        const bodyDividers = boolean('showDividers', true, bodyGroupId);
 
         const numberLinksGroup1 = number(
             'links1',
@@ -313,8 +314,9 @@ stories.add(
                             activeIconColor={bodyActiveIconColor}
                             chevron={bodyChevron}
                         >
-                            <DrawerNavGroup items={links1(state)} title={groupTitle1} />
+                            <DrawerNavGroup divider={bodyDividers} items={links1(state)} title={groupTitle1} />
                             <DrawerNavGroup
+                                divider={bodyDividers}
                                 items={links2(state)}
                                 content={
                                     <div style={{ display: 'flex', justifyContent: 'space-between' }}>

--- a/react/docs/Drawer.md
+++ b/react/docs/Drawer.md
@@ -86,6 +86,7 @@ A `DrawerNavGroup` will render inside of the `DrawerBody` and is used to organiz
 | activeIconColor       | Icon color for the 'active' item        | `string`          | no       |         | 
 | backgroundColor       | The color used for the background       | `string`          | no       |         |   
 | content               | Custom element, substitute for title    | `React.Component` | no       |         |    
+| divider               | Whether to show a line between items    | `boolean`         | no       | true    |    
 | fontColor             | The color used for the text             | `string`          | no       |         |   
 | iconColor             | The color used for the icon             | `string`          | no       |         |   
 | items                 | List of navigation items to render      | `Item[]`          | no       |         |  
@@ -99,6 +100,7 @@ The `items` prop of the `DrawerNavGroup` takes a list of items with the followin
 |-----------------|-----------------------------------------|--------------------|----------|------------------------------|
 | active          | Is the item the current active item     | `boolean`          | no       | false                        |  
 | chevron         | Show chevron icon to the right          | `boolean`          | no       | false                        |  
+| divider         | Show a divider line below the item      | `boolean`          | no       | true                         |  
 | icon            | A component to render for the icon      | `React.Component`  | no       |                              |      
 | onClick         | A function to execute when clicked      | `function`         | no       |                              |    
 | statusColor     | Status stripe and icon color            | `string`           | no       |                              |    


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #93 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Add `divider` prop to DrawerNavGroup and NavGroupItem (default true)
- Update showcase
- Update storybook
- Update docs

Since this utilizes the InfoListItem divider prop, it's not configurable to be on the top or the bottom, but we can handle that as a future enhancement to the InfoListItem. Right now, I'm not sure there's a use case for that specificity.
