### PR TITLE
Change default Avatar color for InfoListItem, Remove auto Chevron on RN

### DIFF
--- a/react/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/react/components/src/core/InfoListItem/InfoListItem.tsx
@@ -13,6 +13,7 @@ import { separate, withKeys } from '../utilities';
 //Material-UI Components
 import {
     Avatar,
+    Divider,
     ListItem,
     ListItemAvatar,
     ListItemIcon,
@@ -27,8 +28,6 @@ const useStyles = makeStyles((theme: Theme) =>
             position: 'absolute',
             bottom: 0,
             right: 0,
-            height: 1,
-            backgroundColor: theme.palette.type === 'light' ? Colors.black[100] : Colors.black[700],
         },
         statusStripe: {
             position: 'absolute',
@@ -187,7 +186,7 @@ export const InfoListItem: React.FC<InfoListItemProps> = (props) => {
     return (
         <ListItem style={getWrapperStyle()} onClick={(): void => onClick()} dense={dense}>
             <div className={classes.statusStripe} style={{ backgroundColor: statusColor }} />
-            {divider && <div className={classes.divider} style={{ zIndex: 0, left: divider === 'full' ? 0 : 72 }} />}
+            {divider && <Divider className={classes.divider} style={{ zIndex: 0, left: divider === 'full' ? 0 : 72 }} />}
             {(icon || !hidePadding) && getIcon()}
             {leftComponent}
             <ListItemText

--- a/react/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/react/components/src/core/InfoListItem/InfoListItem.tsx
@@ -1,5 +1,6 @@
-import { CSSProperties } from '@material-ui/core/styles/withStyles';
 import React from 'react';
+import { CSSProperties } from '@material-ui/core/styles/withStyles';
+import PropTypes from 'prop-types';
 
 import { createStyles, makeStyles, Theme, useTheme } from '@material-ui/core/styles';
 import Chevron from '@material-ui/icons/ChevronRight';
@@ -27,7 +28,7 @@ const useStyles = makeStyles((theme: Theme) =>
             bottom: 0,
             right: 0,
             height: 1,
-            backgroundColor: theme.palette.type === 'light' ? Colors.black[50] : Colors.black[700],
+            backgroundColor: theme.palette.type === 'light' ? Colors.black[100] : Colors.black[700],
         },
         statusStripe: {
             position: 'absolute',
@@ -110,7 +111,7 @@ export const InfoListItem: React.FC<InfoListItemProps> = (props) => {
                 ? color(statusColor).isDark()
                     ? Colors.white[50]
                     : Colors.black[500]
-                : theme.palette.primary.contrastText;
+                : Colors.white[50]; // default avatar is dark gray -> white text
         }
         return statusColor ? statusColor : 'inherit';
     };
@@ -122,7 +123,7 @@ export const InfoListItem: React.FC<InfoListItemProps> = (props) => {
                     <Avatar
                         style={{
                             // @ts-ignore TODO: Fix me
-                            backgroundColor: statusColor || theme.palette.primary[500],
+                            backgroundColor: statusColor || Colors.black[500],
                             color: getIconColor(),
                         }}
                     >
@@ -205,3 +206,32 @@ export const InfoListItem: React.FC<InfoListItemProps> = (props) => {
         </ListItem>
     );
 };
+InfoListItem.propTypes = {
+    avatar: PropTypes.bool,
+    backgroundColor: PropTypes.string,
+    chevron: PropTypes.bool,
+    dense: PropTypes.bool,
+    divider: PropTypes.oneOf(['full', 'partial']),
+    fontColor: PropTypes.string,
+    hidePadding: PropTypes.bool,
+    icon: PropTypes.element,
+    iconColor: PropTypes.string,
+    leftComponent: PropTypes.element,
+    onClick: PropTypes.func,
+    rightComponent: PropTypes.element,
+    statusColor: PropTypes.string,
+    style: PropTypes.objectOf(PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number,
+    ])),
+    subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.element]))]),
+    subtitleSeparator: PropTypes.string,
+    title: PropTypes.string.isRequired,
+}
+InfoListItem.defaultProps = {
+    avatar: false,
+    chevron: false,
+    dense: false,
+    hidePadding: false,
+    subtitleSeparator: '\u00B7',
+}

--- a/reactnative/component-demo/storybook/stories/info-list-item/info-list-item.tsx
+++ b/reactnative/component-demo/storybook/stories/info-list-item/info-list-item.tsx
@@ -26,6 +26,7 @@ storiesOf('InfoListItem', module)
   .add('with icon', () => (
     <InfoListItem
       title={text('title', 'Test')}
+      avatar={boolean('avatar', false)}
       IconClass={LeafIcon}
       iconColor={color('iconColor', '#ff3333')}
       subtitle={text('subtitle', 'A simpler view')}
@@ -35,6 +36,7 @@ storiesOf('InfoListItem', module)
     <InfoListItem
       title={text('title', 'Test')}
       IconClass={LeafIcon}
+      avatar={boolean('avatar', false)}
       subtitle={text('subtitle', 'A simpler view')}
       statusColor={color('statusColor', '#ff3333')}
       fontColor={color('fontColor', '#ff3333')}

--- a/reactnative/component-demo/storybook/stories/info-list-item/info-list.tsx
+++ b/reactnative/component-demo/storybook/stories/info-list-item/info-list.tsx
@@ -49,7 +49,8 @@ const createInfoListItemProps = (): InfoListItemProps => {
     subtitle,
     color,
     IconClass,
-    onPress
+    onPress,
+    divider: 'partial'
   }
 }
 
@@ -63,6 +64,5 @@ storiesOf('InfoListItem', module)
         <InfoListItem {...item} />
       }
       keyExtractor={(_, index) => `${index}`}
-      ItemSeparatorComponent={Separator}
     />
   ));

--- a/reactnative/components/src/info-list-item/info-list-item.test.tsx
+++ b/reactnative/components/src/info-list-item/info-list-item.test.tsx
@@ -87,30 +87,32 @@ describe('InfoListItem', () => {
     });
   });
 
-  describe('onPress', () => {
+  describe('chevron', () => {
     let instance: TestRenderer.ReactTestInstance;
-    let onPress: ReturnType<typeof jest.fn>;
 
     describe('when provided', () => {
-      beforeEach(() => {
-        onPress = jest.fn();
+      
+      it('appears when there is no rightComponent', () => {
         instance = TestRenderer.create(
-          <InfoListItem title={'some title'} onPress={onPress} />
+          <InfoListItem title={'some title'} chevron />
         ).root;
-      });
-
-      it('shows its chevron icon', () => {
         expect(instance.findAllByType(Icon)).toHaveLength(1);
+      });
+      
+      it('does not appear when there is a rightComponent', () => {
+        instance = TestRenderer.create(
+          <InfoListItem title={'some title'} chevron rightComponent={<View/>} />
+        ).root;
+        expect(instance.findAllByType(Icon)).toHaveLength(0);
       });
     });
 
-    describe('when provided', () => {
+    describe('when not provided', () => {
       beforeEach(() => {
         instance = TestRenderer.create(
-          <InfoListItem title={'some title'} />
+          <InfoListItem title={'some title'} onPress={() => {}} />
         ).root;
       });
-
       it('does not show its chevron', () => {
         expect(instance.findAllByType(Icon)).toHaveLength(0);
       });

--- a/reactnative/components/src/info-list-item/info-list-item.tsx
+++ b/reactnative/components/src/info-list-item/info-list-item.tsx
@@ -6,6 +6,8 @@ import { Theme, withTheme, WithTheme } from '../theme';
 import { Body, Subtitle } from '../typography';
 import { $DeepPartial } from '@callstack/react-theme-provider';
 import * as Colors from '@pxblue/colors';
+//@ts-ignore
+import color from 'color';
 
 export interface InfoListItemProps {
   /** Title to show */
@@ -38,6 +40,9 @@ export interface InfoListItemProps {
   /* Hide left padding when icon is not present */
   hidePadding?: boolean;
 
+  /* If present, a Chevron will be displayed on the right. This can be overridden by rightComponent. */
+  chevron?: boolean;
+
   /* Reduce overall height of listItem */
   dense?: boolean;
 
@@ -47,7 +52,7 @@ export interface InfoListItemProps {
   /* Component to render on the right */
   rightComponent?: JSX.Element;
 
-  /** Callback to be called on press. If provided, will add chevron on the right side of the item */
+  /** Callback to be called on press. */
   onPress?: () => void;
 
   /**
@@ -74,7 +79,7 @@ class InfoListItemClass extends Component<WithTheme<InfoListItemProps>> {
     };
 
     return (
-      <View style={[fixedHeight,style]}>
+      <View style={[fixedHeight, style]}>
         <TouchableOpacity onPress={onPress} style={[fullHeight, row, withRightPadding]} disabled={!onPress} activeOpacity={0.7}>
           <View style={[fullHeight, tab, { backgroundColor: statusColor }]} />
           {this.props.IconClass || !this.props.hidePadding ?
@@ -113,23 +118,25 @@ class InfoListItemClass extends Component<WithTheme<InfoListItemProps>> {
     const { avatar, statusColor, iconColor, theme } = this.props;
     if (iconColor) return iconColor;
     if (avatar) {
-      return statusColor ? theme.colors.onPrimary : theme.colors.text;
+      return statusColor ? 
+        (color(statusColor).isDark() ? Colors.white[50] : Colors.black[500])
+        : Colors.white[50]; // default avatar is dark gray -> white text
     }
     return statusColor ? statusColor : theme.colors.text;
   }
   private avatarStyle() {
-    const { theme, statusColor } = this.props;
+    const { statusColor } = this.props;
     const avatarStyle = { ...styles.avatar };
-    avatarStyle.backgroundColor = statusColor || theme.colors.primary;
+    avatarStyle.backgroundColor = statusColor || Colors.black[500];
     return avatarStyle;
   }
 
   private rightComponent() {
-    const { onPress, theme, rightComponent } = this.props;
-    if (rightComponent){
+    const { chevron, theme, rightComponent } = this.props;
+    if (rightComponent) {
       return rightComponent;
     }
-    else if (onPress) {
+    else if (chevron) {
       return (
         <Icon name="chevron-right" size={24} color={theme.colors.text} />
       );
@@ -237,7 +244,7 @@ const styles = StyleSheet.create({
   divider: {
     height: 1,
     borderBottomWidth: 1,
-    borderColor: Colors.black['50']
+    borderColor: Colors.black['100']
   },
   tab: {
     width: 6

--- a/reactnative/docs/infoListItem.md
+++ b/reactnative/docs/infoListItem.md
@@ -38,6 +38,7 @@ You can also supply an array of items that will be displayed as a character-sepa
 | iconColor         | The color of the primary icon           | `string`                                           | no       |                     | 'red'                                   |
 | hidePadding       | Remove left padding if no icon is used  | `boolean`                                          | no       | false               |                                         |
 | avatar            | Show colored background for icon        | `boolean`                                          | no       | false               |                                         |
+| chevron           | Add a chevron icon on the right         | `boolean`                                          | no       | false               |                                         |
 | dense             | Smaller height row with less padding    | `boolean`                                          | no       | false               |                                         |
 | divider           | Show a row separator below the row      | 'full' &vert; 'partial'                            | no       |                     |                                         |
 | rightComponent    | Component to render on the right side   | `JSX.Element`                                      | no       |                     | `<ChannelValue/>`                       |


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #73 
Fixes #88 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Change the default avatar color for InfoListItems to black[500] (default text color) instead of blue[500]
- Update React InfoListItem to use Divider component from MUI
- Make the chevron property configurable (default false) for the RN infolistitem instead of basing it on onPress
- Update necessary tests, stories, and documentation
