### PR TITLE
Add propTypes and displayNames to all react components

### DIFF
--- a/react/components/src/core/ChannelValue/ChannelValue.tsx
+++ b/react/components/src/core/ChannelValue/ChannelValue.tsx
@@ -87,7 +87,7 @@ export const ChannelValue: React.FC<ChannelValueProps> = (props) => {
 
 ChannelValue.displayName = 'ChannelValue';
 ChannelValue.propTypes = {
-    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
     icon: PropTypes.element,
     units: PropTypes.string,
     prefix: PropTypes.bool,

--- a/react/components/src/core/ChannelValue/ChannelValue.tsx
+++ b/react/components/src/core/ChannelValue/ChannelValue.tsx
@@ -38,7 +38,7 @@ export type ChannelValueProps = {
 };
 
 export const ChannelValue: React.FC<ChannelValueProps> = (props) => {
-    const { color = 'inherit', fontSize = 'inherit', icon, prefix = false, value, units } = props;
+    const { color, fontSize, icon, prefix, value, units } = props;
     const classes = styles(props);
 
     const getUnitElement = useCallback(
@@ -93,4 +93,9 @@ ChannelValue.propTypes = {
     prefix: PropTypes.bool,
     fontSize: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     color: PropTypes.string,
+};
+ChannelValue.defaultProps = {
+    color: 'inherit',
+    fontSize: 'inherit',
+    prefix: false,
 };

--- a/react/components/src/core/ChannelValue/ChannelValue.tsx
+++ b/react/components/src/core/ChannelValue/ChannelValue.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import Typography from '@material-ui/core/Typography';
 import { combine } from '../utilities';
 import { makeStyles } from '@material-ui/core/styles';
+import PropTypes from 'prop-types';
 
 const styles = makeStyles({
     wrapper: {
@@ -82,4 +83,14 @@ export const ChannelValue: React.FC<ChannelValueProps> = (props) => {
             {!prefix && getUnitElement()}
         </span>
     );
+};
+
+ChannelValue.displayName = 'ChannelValue';
+ChannelValue.propTypes = {
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    icon: PropTypes.element,
+    units: PropTypes.string,
+    prefix: PropTypes.bool,
+    fontSize: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    color: PropTypes.string,
 };

--- a/react/components/src/core/Drawer/Drawer.tsx
+++ b/react/components/src/core/Drawer/Drawer.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { createStyles, makeStyles, Theme, useTheme } from '@material-ui/core/styles';
 import { Drawer, DrawerProps } from '@material-ui/core';
 import Hidden from '@material-ui/core/Hidden';
+import PropTypes from 'prop-types';
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -131,4 +132,10 @@ export const DrawerComponent: React.FC<DrawerComponentProps> = (props) => {
             <Hidden xsDown>{getDesktopNavigationMenu()}</Hidden>
         </>
     );
+};
+
+DrawerComponent.displayName = 'PXBlueDrawer';
+DrawerComponent.propTypes = {
+    open: PropTypes.bool.isRequired,
+    width: PropTypes.number,
 };

--- a/react/components/src/core/Drawer/DrawerBody.tsx
+++ b/react/components/src/core/Drawer/DrawerBody.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import * as Colors from '@pxblue/colors';
+import PropTypes from 'prop-types';
 
 const useStyles = makeStyles({
     root: {
@@ -62,4 +63,17 @@ export const DrawerBody: React.FC<DrawerBodyProps> = (props) => {
 DrawerBody.displayName = 'DrawerBody';
 DrawerBody.defaultProps = {
     backgroundColor: Colors.white[50], // TODO, dark theme compatible
+};
+
+DrawerBody.propTypes = {
+    activeBackgroundColor: PropTypes.string,
+    activeFontColor: PropTypes.string,
+    activeIconColor: PropTypes.string,
+    backgroundColor: PropTypes.string,
+    chevron: PropTypes.bool,
+    fontColor: PropTypes.string,
+    iconColor: PropTypes.string,
+    onSelect: PropTypes.func,
+    open: PropTypes.bool,
+    titleColor: PropTypes.string,
 };

--- a/react/components/src/core/Drawer/DrawerFooter.tsx
+++ b/react/components/src/core/Drawer/DrawerFooter.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
+import PropTypes from 'prop-types';
 
 const useStyles = makeStyles({
     root: {
@@ -29,3 +30,8 @@ export const DrawerFooter: React.FC<DrawerFooterProps> = (props) => {
 };
 
 DrawerFooter.displayName = 'DrawerFooter';
+
+DrawerFooter.propTypes = {
+    backgroundColor: PropTypes.string,
+    open: PropTypes.bool,
+};

--- a/react/components/src/core/Drawer/DrawerHeader.tsx
+++ b/react/components/src/core/Drawer/DrawerHeader.tsx
@@ -5,6 +5,7 @@ import IconButton from '@material-ui/core/IconButton';
 import Divider from '@material-ui/core/Divider';
 import * as Colors from '@pxblue/colors';
 import { Typography } from '@material-ui/core';
+import PropTypes from 'prop-types';
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -145,4 +146,15 @@ DrawerHeader.displayName = 'DrawerHeader';
 DrawerHeader.defaultProps = {
     backgroundOpacity: 0.3,
     fontColor: Colors.white[50], // TODO: Dark Theme
+};
+DrawerHeader.propTypes = {
+    backgroundColor: PropTypes.string,
+    backgroundImage: PropTypes.string,
+    backgroundOpacity: PropTypes.number,
+    fontColor: PropTypes.string,
+    icon: PropTypes.element,
+    onIconClick: PropTypes.func,
+    subtitle: PropTypes.string,
+    title: PropTypes.string,
+    titleContent: PropTypes.element,
 };

--- a/react/components/src/core/Drawer/DrawerNavGroup.tsx
+++ b/react/components/src/core/Drawer/DrawerNavGroup.tsx
@@ -5,6 +5,7 @@ import ListSubheader from '@material-ui/core/ListSubheader';
 import { Typography } from '@material-ui/core';
 import Divider from '@material-ui/core/Divider';
 import { InfoListItem } from '../InfoListItem';
+import PropTypes from 'prop-types';
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -161,3 +162,31 @@ export const DrawerNavGroup: React.FC<DrawerNavGroupProps> = (props) => {
 };
 
 DrawerNavGroup.displayName = 'DrawerNavGroup';
+
+DrawerNavGroup.propTypes = {
+    activeBackgroundColor: PropTypes.string,
+    activeFontColor: PropTypes.string,
+    activeIconColor: PropTypes.string,
+    backgroundColor: PropTypes.string,
+    chevron: PropTypes.bool,
+    content: PropTypes.element,
+    fontColor: PropTypes.string,
+    iconColor: PropTypes.string,
+    // @ts-ignore
+    items: PropTypes.arrayOf(
+        PropTypes.shape({
+            active: PropTypes.bool,
+            icon: PropTypes.element,
+            onClick: PropTypes.func,
+            statusColor: PropTypes.string,
+            subtitle: PropTypes.string,
+            title: PropTypes.string.isRequired,
+            divider: PropTypes.bool,
+        })
+    ).isRequired,
+    onSelect: PropTypes.func,
+    open: PropTypes.bool,
+    title: PropTypes.string,
+    titleColor: PropTypes.string,
+    divider: PropTypes.bool,
+};

--- a/react/components/src/core/Drawer/DrawerSubheader.tsx
+++ b/react/components/src/core/Drawer/DrawerSubheader.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Divider } from '@material-ui/core';
+import PropTypes from 'prop-types';
 
 export type DrawerSubheaderProps = {
     open?: boolean;
@@ -13,3 +14,7 @@ export const DrawerSubheader: React.FC<DrawerSubheaderProps> = (props) => (
 );
 
 DrawerSubheader.displayName = 'DrawerSubheader';
+
+DrawerSubheader.propTypes = {
+    open: PropTypes.bool,
+};

--- a/react/components/src/core/DrawerLayout/DrawerLayout.tsx
+++ b/react/components/src/core/DrawerLayout/DrawerLayout.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
+import PropTypes from 'prop-types';
 
 export type DrawerLayoutProps = {
     children: React.ReactNode;
@@ -32,4 +33,10 @@ export const DrawerLayout: React.FC<DrawerLayoutProps> = (props) => {
             <div className={classes.content}>{children}</div>
         </div>
     );
+};
+
+DrawerLayout.displayName = 'DrawerLayout';
+DrawerLayout.propTypes = {
+    children: PropTypes.element.isRequired,
+    drawer: PropTypes.element.isRequired,
 };

--- a/react/components/src/core/EmptyState/EmptyState.tsx
+++ b/react/components/src/core/EmptyState/EmptyState.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
-import { makeStyles, StyleRules } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
+import { CSSProperties } from '@material-ui/core/styles/withStyles';
 import * as Colors from '@pxblue/colors';
 import Typography from '@material-ui/core/Typography';
+import PropTypes from 'prop-types';
 
 export type EmptyStateProps = {
     title?: string;
     description?: string;
     icon?: JSX.Element;
     actions?: JSX.Element;
-    iconStyles?: StyleRules;
+    iconStyles?: CSSProperties;
 };
 
 const useStyles = makeStyles({
@@ -45,4 +47,13 @@ export const EmptyState: React.FC<EmptyStateProps> = (props) => {
             {actions && <div style={{ marginTop: '10px' }}>{actions}</div>}
         </div>
     );
+};
+
+EmptyState.displayName = 'EmptyState';
+EmptyState.propTypes = {
+    title: PropTypes.string,
+    description: PropTypes.string,
+    icon: PropTypes.element,
+    actions: PropTypes.element,
+    iconStyles: PropTypes.objectOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
 };

--- a/react/components/src/core/EmptyState/EmptyState.tsx
+++ b/react/components/src/core/EmptyState/EmptyState.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { makeStyles, StyleRules } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import { CSSProperties } from '@material-ui/core/styles/withStyles';
 import * as Colors from '@pxblue/colors';
 import Typography from '@material-ui/core/Typography';

--- a/react/components/src/core/EmptyState/EmptyState.tsx
+++ b/react/components/src/core/EmptyState/EmptyState.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, StyleRules } from '@material-ui/core/styles';
 import { CSSProperties } from '@material-ui/core/styles/withStyles';
 import * as Colors from '@pxblue/colors';
 import Typography from '@material-ui/core/Typography';

--- a/react/components/src/core/Hero/Hero.tsx
+++ b/react/components/src/core/Hero/Hero.tsx
@@ -3,6 +3,7 @@ import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import * as Colors from '@pxblue/colors';
 import { ChannelValue } from '../ChannelValue';
+import PropTypes from 'prop-types';
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -111,4 +112,18 @@ export const Hero = (props: HeroProps): JSX.Element => {
             </Typography>
         </div>
     );
+};
+
+Hero.displayName = 'Hero';
+Hero.propType = {
+    children: PropTypes.element,
+    fontSize: PropTypes.oneOf(['normal', 'small']),
+    icon: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+    iconBackgroundColor: PropTypes.string,
+    iconSize: PropTypes.number,
+    label: PropTypes.string.isRequired,
+    onClick: PropTypes.func,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    valueIcon: PropTypes.element,
+    units: PropTypes.string,
 };

--- a/react/components/src/core/Hero/Hero.tsx
+++ b/react/components/src/core/Hero/Hero.tsx
@@ -72,17 +72,7 @@ export type HeroProps = {
 
 export const Hero = (props: HeroProps): JSX.Element => {
     const classes = useStyles(props);
-    const {
-        fontSize = 'normal',
-        icon,
-        iconBackgroundColor = 'transparent',
-        iconSize = 36,
-        label,
-        onClick,
-        value,
-        valueIcon,
-        units,
-    } = props;
+    const { fontSize, icon, iconBackgroundColor, iconSize, label, onClick, value, valueIcon, units } = props;
 
     return (
         <div
@@ -126,4 +116,9 @@ Hero.propType = {
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     valueIcon: PropTypes.element,
     units: PropTypes.string,
+};
+Hero.defaultProps = {
+    fontSize: 'normal',
+    iconBackgroundColor: 'transparent',
+    iconSize: 36,
 };

--- a/react/components/src/core/HeroBanner/HeroBanner.tsx
+++ b/react/components/src/core/HeroBanner/HeroBanner.tsx
@@ -17,7 +17,7 @@ export type HeroBannerProps = {
 };
 
 export const HeroBanner = (props: HeroBannerProps & any): JSX.Element => {
-    const { divider = false, limit = 4 } = props;
+    const { divider, limit } = props;
     const classes = useStyles(props);
     const isArray = Array.isArray(props.children);
 
@@ -36,4 +36,8 @@ HeroBanner.displayName = 'HeroBanner';
 HeroBanner.propType = {
     divider: PropTypes.bool,
     limit: PropTypes.number,
+};
+HeroBanner.defaultProps = {
+    divider: false,
+    limit: 4,
 };

--- a/react/components/src/core/HeroBanner/HeroBanner.tsx
+++ b/react/components/src/core/HeroBanner/HeroBanner.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Divider from '@material-ui/core/Divider';
+import PropTypes from 'prop-types';
 
 const useStyles = makeStyles({
     banner: {
@@ -29,4 +30,10 @@ export const HeroBanner = (props: HeroBannerProps & any): JSX.Element => {
             {divider && <Divider />}
         </React.Fragment>
     );
+};
+
+HeroBanner.displayName = 'HeroBanner';
+HeroBanner.propType = {
+    divider: PropTypes.bool,
+    limit: PropTypes.number,
 };

--- a/react/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/react/components/src/core/InfoListItem/InfoListItem.tsx
@@ -38,7 +38,7 @@ const useStyles = makeStyles((theme: Theme) =>
             zIndex: 100,
         },
         withSmallMargins: {
-            margin: `0 ${theme.spacing(0.5)}`
+            margin: `0 ${theme.spacing(0.5)}`,
         },
         title: {
             fontWeight: 600,
@@ -211,6 +211,8 @@ export const InfoListItem: React.FC<InfoListItemProps> = (props) => {
         </ListItem>
     );
 };
+
+InfoListItem.displayName = 'InfoListItem';
 InfoListItem.propTypes = {
     avatar: PropTypes.bool,
     backgroundColor: PropTypes.string,

--- a/react/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/react/components/src/core/InfoListItem/InfoListItem.tsx
@@ -84,22 +84,22 @@ export const InfoListItem: React.FC<InfoListItemProps> = (props) => {
     const theme = useTheme();
     const classes = useStyles(theme);
     const {
-        avatar = false,
+        avatar,
         backgroundColor,
-        chevron = false,
-        dense = false,
+        chevron,
+        dense,
         divider,
         fontColor,
-        hidePadding = false,
+        hidePadding,
         icon,
         iconColor,
         leftComponent,
-        onClick = (): void => {},
+        onClick,
         rightComponent,
         statusColor,
         style,
         subtitle,
-        subtitleSeparator = '\u00B7',
+        subtitleSeparator,
         title,
     } = props;
 
@@ -203,7 +203,7 @@ export const InfoListItem: React.FC<InfoListItemProps> = (props) => {
                     noWrap: true,
                     variant: 'body1',
                     className: classes.title,
-                    style: { color: fontColor || 'inherit' },
+                    style: { color: fontColor },
                 }}
                 secondaryTypographyProps={{ noWrap: true, variant: 'subtitle2', className: classes.subtitle }}
             />
@@ -240,5 +240,7 @@ InfoListItem.defaultProps = {
     chevron: false,
     dense: false,
     hidePadding: false,
+    onClick: (): void => {},
     subtitleSeparator: '\u00B7',
+    fontColor: 'inherit',
 };

--- a/react/components/src/core/ListItemTag/ListItemTag.tsx
+++ b/react/components/src/core/ListItemTag/ListItemTag.tsx
@@ -27,7 +27,7 @@ const useStyles = makeStyles((theme: Theme) =>
             paddingRight: theme.spacing(0.5),
             lineHeight: 'inherit',
             color: theme.palette.primary.contrastText,
-            overflow: 'hidden'
+            overflow: 'hidden',
         },
     })
 );
@@ -78,4 +78,4 @@ ListItemTag.defaultProps = {
     noWrap: true,
     variant: 'overline',
     display: 'inline',
-}
+};

--- a/react/components/src/core/ScoreCard/ScoreCard.tsx
+++ b/react/components/src/core/ScoreCard/ScoreCard.tsx
@@ -79,11 +79,11 @@ export type ScoreCordProps = {
 export const ScoreCard: React.FC<ScoreCordProps> = (props) => {
     const classes = useStyles(props);
     const {
-        actionLimit = 3,
+        actionLimit,
         actionItems,
         actionRow,
         badge,
-        badgeOffset = 0,
+        badgeOffset,
         headerBackgroundImage,
         children,
         headerColor,
@@ -222,4 +222,8 @@ ScoreCard.propTypes = {
     headerTitle: PropTypes.string.isRequired,
     headerSubtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     style: PropTypes.objectOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
+};
+ScoreCard.defaultProps = {
+    actionLimit: 3,
+    badgeOffset: 0,
 };

--- a/react/components/src/core/ScoreCard/ScoreCard.tsx
+++ b/react/components/src/core/ScoreCard/ScoreCard.tsx
@@ -2,6 +2,7 @@ import { CSSProperties } from '@material-ui/styles';
 import React from 'react';
 import { Card, Typography, Divider, Theme, makeStyles, createStyles } from '@material-ui/core';
 import * as Colors from '@pxblue/colors';
+import PropTypes from 'prop-types';
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -16,9 +17,7 @@ const useStyles = makeStyles((theme: Theme) =>
         header: {
             height: 100,
             overflow: 'hidden',
-            // TODO: FIX ME!
-            //@ts-ignore
-            backgroundColor: theme.palette.primary[500],
+            backgroundColor: theme.palette.primary.main,
             position: 'relative',
         },
         headerContent: {
@@ -207,4 +206,20 @@ export const ScoreCard: React.FC<ScoreCordProps> = (props) => {
             {getFooter()}
         </Card>
     );
+};
+
+ScoreCard.displayName = 'ScoreCard';
+ScoreCard.propTypes = {
+    actionItems: PropTypes.arrayOf(PropTypes.element),
+    actionLimit: PropTypes.number,
+    actionRow: PropTypes.element,
+    badge: PropTypes.element,
+    badgeOffset: PropTypes.number,
+    headerBackgroundImage: PropTypes.string,
+    headerColor: PropTypes.string,
+    headerFontColor: PropTypes.string,
+    headerInfo: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    headerTitle: PropTypes.string.isRequired,
+    headerSubtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    style: PropTypes.objectOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
 };

--- a/react/components/src/core/Utility/Spacer.tsx
+++ b/react/components/src/core/Utility/Spacer.tsx
@@ -15,7 +15,7 @@ export type SpacerClasses = {
 };
 
 export const Spacer: React.FC<SpacerProps> = (props) => {
-    const { flex = 1, width, height, children, classes = {}, style } = props;
+    const { flex, width, height, children, classes, style } = props;
 
     return (
         <div

--- a/react/components/src/core/Utility/Spacer.tsx
+++ b/react/components/src/core/Utility/Spacer.tsx
@@ -34,6 +34,8 @@ export const Spacer: React.FC<SpacerProps> = (props) => {
         </div>
     );
 };
+
+Spacer.displayName = 'Spacer';
 Spacer.propTypes = {
     flex: PropTypes.number,
     width: PropTypes.number,

--- a/react/demos/showcase/src/App.js
+++ b/react/demos/showcase/src/App.js
@@ -168,7 +168,7 @@ export default () => {
                                 <List style={{ padding: 0 }}>
                                     <ListItem>
                                         <ListItemText primary="View Location" />
-                                        <ListItemSecondaryAction> <ChevronRight /> </ListItemSecondaryAction>
+                                        <ListItemSecondaryAction style={{display: 'flex'}}> <ChevronRight /> </ListItemSecondaryAction>
                                     </ListItem>
                                 </List>
                             }
@@ -221,7 +221,7 @@ export default () => {
                                 <List style={{ padding: 0 }}>
                                     <ListItem>
                                         <ListItemText primary="View Location" />
-                                        <ListItemSecondaryAction> <ChevronRight /> </ListItemSecondaryAction>
+                                        <ListItemSecondaryAction style={{display: 'flex'}}> <ChevronRight /> </ListItemSecondaryAction>
                                     </ListItem>
                                 </List>
                             }

--- a/react/demos/storybook/.storybook/styles.css
+++ b/react/demos/storybook/.storybook/styles.css
@@ -12,6 +12,6 @@ body,
     justify-content: center;
     background: #efefef;
 }
-*{
+* {
     box-sizing: border-box;
 }

--- a/react/demos/storybook/stories/list-item-tag.stories.tsx
+++ b/react/demos/storybook/stories/list-item-tag.stories.tsx
@@ -19,13 +19,13 @@ stories.add('with different colors', () => (
             label={text('label', 'active')}
             backgroundColor={color('backgroundColor', Colors.gold['500'])}
             fontColor={color('fontColor', Colors.black['500'])}
-            style={{boxSizing: 'border-box'}}
+            style={{ boxSizing: 'border-box' }}
         />
     </div>
 ));
 
 stories.add('with additional Typography props', () => (
-    <div style={{ display: 'flex', justifyContent: 'center'}}>
+    <div style={{ display: 'flex', justifyContent: 'center' }}>
         <ListItemTag
             label={text('label', 'clickable')}
             backgroundColor={color('backgroundColor', Colors.green['700'])}
@@ -52,7 +52,11 @@ stories.add('with additional Typography props', () => (
                 ],
                 'overline'
             )}
-            style={{ padding: text('style.padding', '0 4px'), width: text('style.width', 'initial'), boxSizing: 'border-box'  }}
+            style={{
+                padding: text('style.padding', '0 4px'),
+                width: text('style.width', 'initial'),
+                boxSizing: 'border-box',
+            }}
             paragraph={boolean('paragraph', false)}
             noWrap={boolean('noWrap', true)}
         />

--- a/react/demos/storybook/stories/score-card.stories.tsx
+++ b/react/demos/storybook/stories/score-card.stories.tsx
@@ -74,7 +74,7 @@ stories.add('background and actions', () => (
             <List style={{ margin: 0 }}>
                 <ListItem>
                     <ListItemText primary="View Location" />
-                    <ListItemSecondaryAction>
+                    <ListItemSecondaryAction style={{display: 'flex'}}>
                         {' '}
                         <ChevronRight />{' '}
                     </ListItemSecondaryAction>
@@ -103,7 +103,7 @@ stories.add('with hero badges', () => (
             <List style={{ margin: 0 }}>
                 <ListItem>
                     <ListItemText primary="View Location" />
-                    <ListItemSecondaryAction>
+                    <ListItemSecondaryAction style={{display: 'flex'}}>
                         {' '}
                         <ChevronRight />{' '}
                     </ListItemSecondaryAction>
@@ -137,7 +137,7 @@ stories.add('with score badge', () => (
             <List style={{ margin: 0 }}>
                 <ListItem>
                     <ListItemText primary="View Location" />
-                    <ListItemSecondaryAction>
+                    <ListItemSecondaryAction style={{display: 'flex'}}>
                         {' '}
                         <ChevronRight />{' '}
                     </ListItemSecondaryAction>
@@ -195,7 +195,7 @@ stories.add('full configuration', () => (
             <List style={{ margin: 0 }}>
                 <ListItem>
                     <ListItemText primary="View Location" />
-                    <ListItemSecondaryAction>
+                    <ListItemSecondaryAction style={{display: 'flex'}}>
                         {' '}
                         <ChevronRight />{' '}
                     </ListItemSecondaryAction>

--- a/react/demos/storybook/stories/score-card.stories.tsx
+++ b/react/demos/storybook/stories/score-card.stories.tsx
@@ -74,7 +74,7 @@ stories.add('background and actions', () => (
             <List style={{ margin: 0 }}>
                 <ListItem>
                     <ListItemText primary="View Location" />
-                    <ListItemSecondaryAction style={{display: 'flex'}}>
+                    <ListItemSecondaryAction style={{ display: 'flex' }}>
                         {' '}
                         <ChevronRight />{' '}
                     </ListItemSecondaryAction>
@@ -103,7 +103,7 @@ stories.add('with hero badges', () => (
             <List style={{ margin: 0 }}>
                 <ListItem>
                     <ListItemText primary="View Location" />
-                    <ListItemSecondaryAction style={{display: 'flex'}}>
+                    <ListItemSecondaryAction style={{ display: 'flex' }}>
                         {' '}
                         <ChevronRight />{' '}
                     </ListItemSecondaryAction>
@@ -137,7 +137,7 @@ stories.add('with score badge', () => (
             <List style={{ margin: 0 }}>
                 <ListItem>
                     <ListItemText primary="View Location" />
-                    <ListItemSecondaryAction style={{display: 'flex'}}>
+                    <ListItemSecondaryAction style={{ display: 'flex' }}>
                         {' '}
                         <ChevronRight />{' '}
                     </ListItemSecondaryAction>
@@ -195,7 +195,7 @@ stories.add('full configuration', () => (
             <List style={{ margin: 0 }}>
                 <ListItem>
                     <ListItemText primary="View Location" />
-                    <ListItemSecondaryAction style={{display: 'flex'}}>
+                    <ListItemSecondaryAction style={{ display: 'flex' }}>
                         {' '}
                         <ChevronRight />{' '}
                     </ListItemSecondaryAction>

--- a/react/package.json
+++ b/react/package.json
@@ -22,7 +22,7 @@
     "@pxblue/colors": "^2.0.0",
     "@pxblue/eslint-config": "1.1.3",
     "@pxblue/prettier-config": "1.0.2",
-    "@pxblue/themes": "^1.0.26",
+    "@pxblue/themes": "^3.0.2",
     "@types/enzyme": "^3.10.4",
     "@types/enzyme-adapter-react-16": "^1.0.5",
     "@types/jest": "^24.9.0",


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #90  .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Add `propTypes` and `displayName` to all react components
- Bump version of `@pxblue/themes` to use ^3.0.2
- Add display flex to score card `ListItemSecondaryAction` in demo projects 
