### PR TITLE
Configure storybook to not escape HTML chars

### DIFF
--- a/react/demos/storybook/.storybook/config.js
+++ b/react/demos/storybook/.storybook/config.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { configure, addDecorator, addParameters } from '@storybook/react';
+import { withKnobs } from '@storybook/addon-knobs';
 import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import { ReactThemes } from '@pxblue/themes';
 import * as Colors from '@pxblue/colors';
@@ -47,6 +48,8 @@ addDecorator((storyFn) => (
         </div>
     </MuiThemeProvider>
 ));
+
+addDecorator(withKnobs({escapeHTML: false}));
 
 // automatically import all files ending in *.stories.js
 configure(require.context('../stories', true, /\.stories\.(js|tsx)$/), module);

--- a/react/demos/storybook/stories/channel-value.stories.tsx
+++ b/react/demos/storybook/stories/channel-value.stories.tsx
@@ -1,12 +1,11 @@
 import Trend from '@material-ui/icons/TrendingUp';
 import * as Colors from '@pxblue/colors';
 import { ChannelValue } from '@pxblue/react-components';
-import { boolean, number, text, withKnobs, color } from '@storybook/addon-knobs';
+import { boolean, number, text, color } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 
 export const stories = storiesOf('Channel Value', module);
-stories.addDecorator(withKnobs);
 stories.addParameters({
     notes: { markdown: require('./../../../docs/ChannelValue.md') },
 });

--- a/react/demos/storybook/stories/drawer-layout.stories.tsx
+++ b/react/demos/storybook/stories/drawer-layout.stories.tsx
@@ -4,14 +4,13 @@ import MenuIcon from '@material-ui/icons/Menu';
 import { Drawer, DrawerBody, DrawerFooter, DrawerHeader, DrawerNavGroup } from '@pxblue/react-components/core/Drawer';
 import { DrawerLayout } from '@pxblue/react-components';
 import { action } from '@storybook/addon-actions';
-import { boolean, number, withKnobs } from '@storybook/addon-knobs';
+import { boolean, number } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 // @ts-ignore
 import EatonLogo from '../assets/EatonLogo.svg';
 
 export const stories = storiesOf('Drawer Layout', module);
-stories.addDecorator(withKnobs);
 stories.addParameters({
     notes: { markdown: require('./../../../docs/DrawerLayout.md') },
 });

--- a/react/demos/storybook/stories/drawer.stories.tsx
+++ b/react/demos/storybook/stories/drawer.stories.tsx
@@ -36,7 +36,7 @@ import {
     NavItem,
 } from '@pxblue/react-components';
 import { State, Store } from '@sambego/storybook-state';
-import { boolean, color, number, optionsKnob, select, text, withKnobs } from '@storybook/addon-knobs';
+import { boolean, color, number, optionsKnob, select, text } from '@storybook/addon-knobs';
 import { OptionsKnobOptionsDisplay } from '@storybook/addon-knobs/dist/components/types/Options';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
@@ -47,7 +47,6 @@ const farmBgImage = require('../assets/farm.jpg');
 
 export const stories = storiesOf('Drawer', module);
 
-stories.addDecorator(withKnobs);
 stories.addParameters({
     notes: { markdown: require('./../../../docs/Drawer.md') },
 });

--- a/react/demos/storybook/stories/empty-state.stories.tsx
+++ b/react/demos/storybook/stories/empty-state.stories.tsx
@@ -7,11 +7,10 @@ import AddIcon from '@material-ui/icons/AddCircleOutlined';
 import Button from '@material-ui/core/Button';
 import AlertIcon from '@material-ui/icons/NotificationImportant';
 import TrendingUpIcon from '@material-ui/icons/TrendingUp';
-import { text, withKnobs } from '@storybook/addon-knobs';
+import { text } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 
 export const stories = storiesOf('Empty State', module);
-stories.addDecorator(withKnobs);
 stories.addParameters({
     notes: { markdown: require('./../../../docs/EmptyState.md') },
 });

--- a/react/demos/storybook/stories/hero-banner.stories.tsx
+++ b/react/demos/storybook/stories/hero-banner.stories.tsx
@@ -4,11 +4,10 @@ import * as Colors from '@pxblue/colors';
 import { Hero, HeroBanner } from '@pxblue/react-components';
 //@ts-ignore
 import { GradeA, Leaf, CurrentCircled, Temp } from '@pxblue/icons-mui';
-import { number, withKnobs } from '@storybook/addon-knobs';
+import { number } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 
 export const stories = storiesOf('Hero Banner', module);
-stories.addDecorator(withKnobs);
 stories.addParameters({
     notes: { markdown: require('./../../../docs/Hero.md') },
 });

--- a/react/demos/storybook/stories/hero.stories.tsx
+++ b/react/demos/storybook/stories/hero.stories.tsx
@@ -5,11 +5,10 @@ import { Hero, ChannelValue } from '@pxblue/react-components';
 //@ts-ignore
 import { GradeA, Leaf } from '@pxblue/icons-mui';
 
-import { text, number, withKnobs } from '@storybook/addon-knobs';
+import { text, number } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 
 export const stories = storiesOf('Hero', module);
-stories.addDecorator(withKnobs);
 stories.addParameters({
     notes: { markdown: require('./../../../docs/Hero.md') },
 });

--- a/react/demos/storybook/stories/info-list-item.stories.tsx
+++ b/react/demos/storybook/stories/info-list-item.stories.tsx
@@ -4,11 +4,10 @@ import * as Colors from '@pxblue/colors';
 import { GradeA, Leaf, Temp, Device } from '@pxblue/icons-mui';
 import { ChannelValue, InfoListItem } from '@pxblue/react-components';
 import { List } from '@material-ui/core';
-import { boolean, color, text, withKnobs } from '@storybook/addon-knobs';
+import { boolean, color, text } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 
 export const stories = storiesOf('Info List Item', module);
-stories.addDecorator(withKnobs);
 stories.addParameters({
     notes: { markdown: require('./../../../docs/InfoListItem.md') },
 });

--- a/react/demos/storybook/stories/list-item-tag.stories.tsx
+++ b/react/demos/storybook/stories/list-item-tag.stories.tsx
@@ -1,14 +1,13 @@
 import { ListItemTag } from '@pxblue/react-components';
 
 import * as Colors from '@pxblue/colors';
-import { text, withKnobs, color, select, boolean } from '@storybook/addon-knobs';
+import { text, color, select, boolean } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 
 export const stories = storiesOf('List Item Tag', module);
 
-stories.addDecorator(withKnobs);
 stories.addParameters({
     notes: { markdown: require('./../../../docs/ListItemTag.md') },
 });

--- a/react/demos/storybook/stories/score-card.stories.tsx
+++ b/react/demos/storybook/stories/score-card.stories.tsx
@@ -6,12 +6,11 @@ import { GradeA, Temp, Moisture as Humidity } from '@pxblue/icons-mui';
 import { MoreVert, Search, Mail, ChevronRight, Notifications, ListAlt, Cloud } from '@material-ui/icons';
 import { InfoListItem, ScoreCard, Hero, HeroBanner } from '@pxblue/react-components';
 import { List, ListItem, ListItemText, ListItemSecondaryAction } from '@material-ui/core';
-import { boolean, color, text, number, withKnobs } from '@storybook/addon-knobs';
+import { boolean, color, text, number } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 const backgroundImage = require('../assets/topology_40.png');
 
 export const stories = storiesOf('Score Card', module);
-stories.addDecorator(withKnobs);
 stories.addParameters({
     notes: { markdown: require('./../../../docs/ScoreCard.md') },
 });

--- a/react/demos/storybook/stories/spacer.stories.tsx
+++ b/react/demos/storybook/stories/spacer.stories.tsx
@@ -2,11 +2,10 @@ import React from 'react';
 import * as Colors from '@pxblue/colors';
 import { Spacer } from '@pxblue/react-components';
 import { Typography } from '@material-ui/core';
-import { number, withKnobs } from '@storybook/addon-knobs';
+import { number } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 
 export const stories = storiesOf('Spacer', module);
-stories.addDecorator(withKnobs);
 stories.addParameters({
     notes: { markdown: require('./../../../docs/Spacer.md') },
 });

--- a/react/demos/storybook/stories/user-menu.stories.tsx
+++ b/react/demos/storybook/stories/user-menu.stories.tsx
@@ -5,7 +5,7 @@ import * as Colors from '@pxblue/colors';
 import { UserMenu, UserMenuGroup } from '@pxblue/react-components';
 import { State, Store } from '@sambego/storybook-state';
 import { action } from '@storybook/addon-actions';
-import { color, text, withKnobs } from '@storybook/addon-knobs';
+import { color, text } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 const EatonLogo = require('../assets/EatonLogo.svg');
@@ -13,7 +13,6 @@ const EatonLogo = require('../assets/EatonLogo.svg');
 const tRex = require('../assets/trex.jpeg');
 
 export const stories = storiesOf('User Menu', module);
-stories.addDecorator(withKnobs);
 stories.addParameters({
     notes: { markdown: require('./../../../docs/UserMenu.md') },
 });


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes issue where text knobs are automatically using HTML escape.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Remove knobs on per-story basis
- Add global knob configuration
- Change knobs to not do the automatic escape
